### PR TITLE
Session/3 エラーハンドリング

### DIFF
--- a/yumemi-ios-training.xcodeproj/project.pbxproj
+++ b/yumemi-ios-training.xcodeproj/project.pbxproj
@@ -14,7 +14,9 @@
 		CE0E249927FE74BF00EDC258 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE0E249727FE74BF00EDC258 /* LaunchScreen.storyboard */; };
 		CE0E24A227FE79EC00EDC258 /* YumemiWeather in Frameworks */ = {isa = PBXBuildFile; productRef = CE0E24A127FE79EC00EDC258 /* YumemiWeather */; };
 		CE0E24A527FE7C4E00EDC258 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = CE0E24A427FE7C4E00EDC258 /* SnapKit */; };
-		CE0E24A927FE8CD200EDC258 /* WeatherUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0E24A827FE8CD200EDC258 /* WeatherUtility.swift */; };
+		CE0E24A927FE8CD200EDC258 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0E24A827FE8CD200EDC258 /* Weather.swift */; };
+		CEC4851A2803B50C0093698E /* WeatherError+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC485192803B50C0093698E /* WeatherError+Localized.swift */; };
+		CEC4851C2803B5410093698E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = CEC4851B2803B5410093698E /* Localizable.strings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,7 +27,9 @@
 		CE0E249527FE74BF00EDC258 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		CE0E249827FE74BF00EDC258 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		CE0E249A27FE74BF00EDC258 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		CE0E24A827FE8CD200EDC258 /* WeatherUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherUtility.swift; sourceTree = "<group>"; };
+		CE0E24A827FE8CD200EDC258 /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
+		CEC485192803B50C0093698E /* WeatherError+Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WeatherError+Localized.swift"; sourceTree = "<group>"; };
+		CEC4851B2803B5410093698E /* Localizable.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -63,10 +67,12 @@
 				CE0E248C27FE74BE00EDC258 /* AppDelegate.swift */,
 				CE0E248E27FE74BE00EDC258 /* SceneDelegate.swift */,
 				CE0E249027FE74BE00EDC258 /* WeatherViewController.swift */,
-				CE0E24A827FE8CD200EDC258 /* WeatherUtility.swift */,
+				CE0E24A827FE8CD200EDC258 /* Weather.swift */,
+				CEC485192803B50C0093698E /* WeatherError+Localized.swift */,
 				CE0E249527FE74BF00EDC258 /* Assets.xcassets */,
 				CE0E249727FE74BF00EDC258 /* LaunchScreen.storyboard */,
 				CE0E249A27FE74BF00EDC258 /* Info.plist */,
+				CEC4851B2803B5410093698E /* Localizable.strings */,
 			);
 			path = "yumemi-ios-training";
 			sourceTree = "<group>";
@@ -138,6 +144,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE0E249927FE74BF00EDC258 /* LaunchScreen.storyboard in Resources */,
+				CEC4851C2803B5410093698E /* Localizable.strings in Resources */,
 				CE0E249627FE74BF00EDC258 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -151,8 +158,9 @@
 			files = (
 				CE0E249127FE74BE00EDC258 /* WeatherViewController.swift in Sources */,
 				CE0E248D27FE74BE00EDC258 /* AppDelegate.swift in Sources */,
+				CEC4851A2803B50C0093698E /* WeatherError+Localized.swift in Sources */,
 				CE0E248F27FE74BE00EDC258 /* SceneDelegate.swift in Sources */,
-				CE0E24A927FE8CD200EDC258 /* WeatherUtility.swift in Sources */,
+				CE0E24A927FE8CD200EDC258 /* Weather.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/yumemi-ios-training/Localizable.strings
+++ b/yumemi-ios-training/Localizable.strings
@@ -1,0 +1,18 @@
+/* YumemiWeatherError */
+"An unknown error occurred." = "不明なエラーが発生しました。";
+
+/* No comment provided by engineer. */
+"Close" = "閉じる";
+
+/* No comment provided by engineer. */
+"OK" = "了解";
+
+/* The title for errors. */
+"Oops!" = "おっと";
+
+/* YumemiWeatherError */
+"Parameters are invalid." = "無効なパラメータです。";
+
+/* No comment provided by engineer. */
+"Reload" = "読み込み";
+

--- a/yumemi-ios-training/Weather.swift
+++ b/yumemi-ios-training/Weather.swift
@@ -1,10 +1,3 @@
-//
-//  WeatherUtility.swift
-//  yumemi-ios-training
-//
-//  Created by Zhou Chang on 2022/04/07.
-//
-
 import UIKit
 
 /// A namespace for weather's properties and assistant functions.

--- a/yumemi-ios-training/WeatherError+Localized.swift
+++ b/yumemi-ios-training/WeatherError+Localized.swift
@@ -1,0 +1,13 @@
+import Foundation
+import YumemiWeather
+
+extension YumemiWeatherError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .invalidParameterError:
+            return NSLocalizedString("Parameters are invalid.", comment: "YumemiWeatherError")
+        case .unknownError:
+            return NSLocalizedString("An unknown error occurred.", comment: "YumemiWeatherError")
+        }
+    }
+}

--- a/yumemi-ios-training/WeatherViewController.swift
+++ b/yumemi-ios-training/WeatherViewController.swift
@@ -76,8 +76,8 @@ class WeatherViewController: UIViewController {
         redLabel.textColor = .systemRed
         redLabel.textAlignment = .center
         
-        closeButton.setTitle("Close", for: .normal)
-        reloadButton.setTitle("Reload", for: .normal)
+        closeButton.setTitle(NSLocalizedString("Close", comment: ""), for: .normal)
+        reloadButton.setTitle(NSLocalizedString("Reload", comment: ""), for: .normal)
         reloadButton.addAction(
             UIAction(handler: { [weak self] _ in self?.reloadWeather() }),
             for: .touchUpInside
@@ -85,7 +85,27 @@ class WeatherViewController: UIViewController {
     }
     
     private func reloadWeather() {
-        let weatherName = YumemiWeather.fetchWeather()
-        imageView.image = Weather.icon(for: weatherName)
+        do {
+            let weatherName = try YumemiWeather.fetchWeather(at: "Tokyo")
+            imageView.image = Weather.icon(for: weatherName)
+        } catch {
+            presentError(error)
+        }
+    }
+    
+    private func presentError(_ error: Error) {
+        let alertController = UIAlertController(
+            title: NSLocalizedString("Oops!", comment: "The title for errors."),
+            message: error.localizedDescription,
+            preferredStyle: .alert
+        )
+        alertController.addAction(
+            UIAlertAction(
+                title: NSLocalizedString("OK", comment: ""),
+                style: .default,
+                handler: nil
+            )
+        )
+        present(alertController, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
## [Session 3](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Error.md)の課題です

- 呼び出しAPIをThrows verに変更する
- 天気予報を画面に表示する
- APIエラーが発生したらUIAlertControllerを表示する
    - エラーの内容に応じてメッセージを変更する
    - メッセージの内容は自由です。エラーを切り分けられていればOK。

## 実装効果

ついでに翻訳を追加しました。

<img src="https://user-images.githubusercontent.com/11924267/162649359-ea0a3fc8-ae39-44a3-895c-c8a1276fbcb2.jpg" width="300">

