### PR TITLE
Session/7 NotificationCenter

### DIFF
--- a/yumemi-ios-training.xcodeproj/project.pbxproj
+++ b/yumemi-ios-training.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		CE0E24A927FE8CD200EDC258 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0E24A827FE8CD200EDC258 /* Weather.swift */; };
 		CE6289562806B7E000518268 /* WeatherRequest+Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6289552806B7E000518268 /* WeatherRequest+Client.swift */; };
 		CEA4A5F2280D02FB00D5A45D /* WeatherIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA4A5F1280D02FB00D5A45D /* WeatherIconView.swift */; };
+		CEA4A5F4280D2A7400D5A45D /* EmptyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA4A5F3280D2A7400D5A45D /* EmptyViewController.swift */; };
 		CEC4851A2803B50C0093698E /* WeatherError+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC485192803B50C0093698E /* WeatherError+Localized.swift */; };
 		CEC4851C2803B5410093698E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = CEC4851B2803B5410093698E /* Localizable.strings */; };
 /* End PBXBuildFile section */
@@ -32,6 +33,7 @@
 		CE0E24A827FE8CD200EDC258 /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		CE6289552806B7E000518268 /* WeatherRequest+Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WeatherRequest+Client.swift"; sourceTree = "<group>"; };
 		CEA4A5F1280D02FB00D5A45D /* WeatherIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherIconView.swift; sourceTree = "<group>"; };
+		CEA4A5F3280D2A7400D5A45D /* EmptyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyViewController.swift; sourceTree = "<group>"; };
 		CEC485192803B50C0093698E /* WeatherError+Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WeatherError+Localized.swift"; sourceTree = "<group>"; };
 		CEC4851B2803B5410093698E /* Localizable.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -101,6 +103,7 @@
 			children = (
 				CE0E248C27FE74BE00EDC258 /* AppDelegate.swift */,
 				CE0E248E27FE74BE00EDC258 /* SceneDelegate.swift */,
+				CEA4A5F3280D2A7400D5A45D /* EmptyViewController.swift */,
 				CE0E249027FE74BE00EDC258 /* WeatherViewController.swift */,
 				CEA4A5F1280D02FB00D5A45D /* WeatherIconView.swift */,
 			);
@@ -188,6 +191,7 @@
 			files = (
 				CEA4A5F2280D02FB00D5A45D /* WeatherIconView.swift in Sources */,
 				CE0E249127FE74BE00EDC258 /* WeatherViewController.swift in Sources */,
+				CEA4A5F4280D2A7400D5A45D /* EmptyViewController.swift in Sources */,
 				CE0E248D27FE74BE00EDC258 /* AppDelegate.swift in Sources */,
 				CEC4851A2803B50C0093698E /* WeatherError+Localized.swift in Sources */,
 				CE0E248F27FE74BE00EDC258 /* SceneDelegate.swift in Sources */,

--- a/yumemi-ios-training/Localizable.strings
+++ b/yumemi-ios-training/Localizable.strings
@@ -1,3 +1,6 @@
+/* No comment provided by engineer. */
+"An error occurred." = "エラーが発生しました。";
+
 /* YumemiWeatherError */
 "An unknown error occurred." = "不明なエラーが発生しました。";
 

--- a/yumemi-ios-training/View/EmptyViewController.swift
+++ b/yumemi-ios-training/View/EmptyViewController.swift
@@ -1,0 +1,18 @@
+//
+//  EmptyViewController.swift
+//  yumemi-ios-training
+//
+//  Created by Zhou Chang on 2022/04/18.
+//
+
+import UIKit
+
+final class EmptyViewController: UIViewController {
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        let weatherViewController = WeatherViewController()
+        weatherViewController.modalPresentationStyle = .fullScreen
+        present(weatherViewController, animated: true, completion: nil)
+    }
+}

--- a/yumemi-ios-training/View/SceneDelegate.swift
+++ b/yumemi-ios-training/View/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = WeatherViewController()
+        window.rootViewController = EmptyViewController()
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/yumemi-ios-training/View/WeatherViewController.swift
+++ b/yumemi-ios-training/View/WeatherViewController.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 import SnapKit
-import YumemiWeather
 
 class WeatherViewController: UIViewController {
     
@@ -100,6 +99,10 @@ class WeatherViewController: UIViewController {
         dateLabel.textAlignment = .center
         
         closeButton.setTitle(NSLocalizedString("Close", comment: ""), for: .normal)
+        closeButton.addAction(
+            UIAction(handler: { [weak self] _ in self?.dismiss(animated: true, completion: nil) }),
+            for: .touchUpInside
+        )
         reloadButton.setTitle(NSLocalizedString("Reload", comment: ""), for: .normal)
         reloadButton.addAction(
             UIAction(handler: { [weak self] _ in self?.reloadWeather() }),

--- a/yumemi-ios-training/View/WeatherViewController.swift
+++ b/yumemi-ios-training/View/WeatherViewController.swift
@@ -34,6 +34,13 @@ class WeatherViewController: UIViewController {
     override func viewDidLoad() {
         addSubviewsAndConstraints()
         setViewsProperties()
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(reloadWeather),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
     }
     
     private func addSubviewsAndConstraints() {
@@ -110,7 +117,7 @@ class WeatherViewController: UIViewController {
         )
     }
     
-    private func reloadWeather() {
+    @objc func reloadWeather() {
         do {
             let weather = try client.fetchWeather(area: "Tokyo")
             showWeather(weather)

--- a/yumemi-ios-training/View/WeatherViewController.swift
+++ b/yumemi-ios-training/View/WeatherViewController.swift
@@ -115,7 +115,7 @@ class WeatherViewController: UIViewController {
             let weather = try client.fetchWeather(area: "Tokyo")
             showWeather(weather)
         } catch {
-            presentError(error, describeError: false)
+            presentError(error, showErrorDetail: false)
         }
     }
     
@@ -126,8 +126,8 @@ class WeatherViewController: UIViewController {
         dateLabel.text = dateFormatter.string(from: weather.date)
     }
     
-    private func presentError(_ error: Error, describeError: Bool) {
-        let errorMessage = describeError ? error.localizedDescription: NSLocalizedString("An unknown error occurred.", comment: "")
+    private func presentError(_ error: Error, showErrorDetail: Bool) {
+        let errorMessage = showErrorDetail ? error.localizedDescription: NSLocalizedString("An error occurred.", comment: "")
         let alertController = UIAlertController(
             title: NSLocalizedString("Oops!", comment: "The title for errors."),
             message: errorMessage,

--- a/yumemi-ios-training/View/WeatherViewController.swift
+++ b/yumemi-ios-training/View/WeatherViewController.swift
@@ -115,7 +115,7 @@ class WeatherViewController: UIViewController {
             let weather = try client.fetchWeather(area: "Tokyo")
             showWeather(weather)
         } catch {
-            presentError(error)
+            presentError(error, describeError: false)
         }
     }
     
@@ -126,10 +126,11 @@ class WeatherViewController: UIViewController {
         dateLabel.text = dateFormatter.string(from: weather.date)
     }
     
-    private func presentError(_ error: Error) {
+    private func presentError(_ error: Error, describeError: Bool) {
+        let errorMessage = describeError ? error.localizedDescription: NSLocalizedString("An unknown error occurred.", comment: "")
         let alertController = UIAlertController(
             title: NSLocalizedString("Oops!", comment: "The title for errors."),
-            message: error.localizedDescription,
+            message: errorMessage,
             preferredStyle: .alert
         )
         alertController.addAction(


### PR DESCRIPTION
## [Session 7 課題](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/NotificationCenter.md)

NotificationCenterを利用して、アプリがバックグラウンドからフォアグラウンドに戻ってきたときに、天気予報を更新する

### Extra
普通のObserverを使っていましたが、Combine を使うならこう
```swift
class WeatherViewController: UIViewController {
    // ...
    private var cancellables: [AnyCancellable] = []
    
    override func viewDidLoad() {
        // ...
        NotificationCenter.Publisher(center: .default, name: UIApplication.willEnterForegroundNotification)
            .sink { [weak self] _ in
                self?.reloadWeather()
            }
            .store(in: &cancellables)
    }
```