### PR TITLE
Session/7 NotificationCenter

### DIFF
--- a/yumemi-ios-training/View/WeatherViewController.swift
+++ b/yumemi-ios-training/View/WeatherViewController.swift
@@ -34,6 +34,13 @@ class WeatherViewController: UIViewController {
     override func viewDidLoad() {
         addSubviewsAndConstraints()
         setViewsProperties()
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(reloadWeather),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
     }
     
     private func addSubviewsAndConstraints() {
@@ -110,7 +117,7 @@ class WeatherViewController: UIViewController {
         )
     }
     
-    private func reloadWeather() {
+    @objc func reloadWeather() {
         do {
             let weather = try client.fetchWeather(area: "Tokyo")
             showWeather(weather)


### PR DESCRIPTION
## [Session 7 課題](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/NotificationCenter.md)

NotificationCenterを利用して、アプリがバックグラウンドからフォアグラウンドに戻ってきたときに、天気予報を更新する

### Extra
普通の Observer を使いましたが、Combine を使うならこうなります。

```swift
import Combine

class WeatherViewController: UIViewController {
    // ...
    private var cancellables: [AnyCancellable] = []
    
    override func viewDidLoad() {
        // ...
        NotificationCenter.Publisher(center: .default, name: UIApplication.willEnterForegroundNotification)
            .sink { [weak self] _ in
                self?.reloadWeather()
            }
            .store(in: &cancellables)
    }
```