### PR TITLE
Session/9&11 スレッドブロック&コールバック

### DIFF
--- a/WeatherTest/WeatherViewControllerTest.swift
+++ b/WeatherTest/WeatherViewControllerTest.swift
@@ -12,17 +12,13 @@ import XCTest
 struct MockWeatherModel: WeatherModel {
     
     var onFetchWeather: (String, Date) throws -> Weather
-    var isLoading = CurrentValueSubject<Bool, Never>(false)
     
-    func fetchWeather(area: String, date: Date) -> AnyPublisher<Weather, Error> {
-        isLoading.send(true)
-        return Future<Weather, Error> { promise in
-            do {
-                promise(.success(try onFetchWeather(area, date)))
-            } catch {
-                promise(.failure(error))
-            }
-        }.eraseToAnyPublisher()
+    func requestWeather(area: String, date: Date, completion: @escaping (Result<Weather, Error>) -> Void) {
+        do {
+            completion(.success(try onFetchWeather(area, date)))
+        } catch {
+            completion(.failure(error))
+        }
     }
 }
 

--- a/WeatherTest/WeatherViewControllerTest.swift
+++ b/WeatherTest/WeatherViewControllerTest.swift
@@ -20,11 +20,18 @@ struct MockWeatherModel: WeatherModel {
 class WeatherViewControllerTest: XCTestCase {
 
     func testSunnyIcon() throws {
+        let expectation = self.expectation(description: "WeatherLoading")
         let weatherModel = MockWeatherModel { _, date in
-            Weather(name: "sunny", maxTemperature: 28, minTemperature: 1, date: date)
+            defer {
+                DispatchQueue.main.async {
+                    expectation.fulfill()
+                }
+            }
+            return Weather(name: "sunny", maxTemperature: 28, minTemperature: 1, date: date)
         }
         let viewController = WeatherViewController(weatherModel: weatherModel)
         viewController.reloadWeather()
+        wait(for: [expectation], timeout: 5)
         
         let renderedImageData = viewController.weatherIconView.image?.pngData()
         let expectedImageData = UIImage(named: "icon-sunny")?.pngData()
@@ -35,11 +42,18 @@ class WeatherViewControllerTest: XCTestCase {
     }
     
     func testRainyIcon() throws {
+        let expectation = self.expectation(description: "WeatherLoading")
         let weatherModel = MockWeatherModel { _, date in
-            Weather(name: "rainy", maxTemperature: 28, minTemperature: 1, date: date)
+            defer {
+                DispatchQueue.main.async {
+                    expectation.fulfill()
+                }
+            }
+            return Weather(name: "rainy", maxTemperature: 28, minTemperature: 1, date: date)
         }
         let viewController = WeatherViewController(weatherModel: weatherModel)
         viewController.reloadWeather()
+        wait(for: [expectation], timeout: 5)
         
         let renderedImageData = viewController.weatherIconView.image?.pngData()
         let expectedImageData = UIImage(named: "icon-rainy")?.pngData()
@@ -50,11 +64,18 @@ class WeatherViewControllerTest: XCTestCase {
     }
     
     func testCloudyIcon() throws {
+        let expectation = self.expectation(description: "WeatherLoading")
         let weatherModel = MockWeatherModel { _, date in
-            Weather(name: "cloudy", maxTemperature: 28, minTemperature: 1, date: date)
+            defer {
+                DispatchQueue.main.async {
+                    expectation.fulfill()
+                }
+            }
+            return Weather(name: "cloudy", maxTemperature: 28, minTemperature: 1, date: date)
         }
         let viewController = WeatherViewController(weatherModel: weatherModel)
         viewController.reloadWeather()
+        wait(for: [expectation], timeout: 5)
         
         let renderedImageData = viewController.weatherIconView.image?.pngData()
         let expectedImageData = UIImage(named: "icon-cloudy")?.pngData()
@@ -65,11 +86,18 @@ class WeatherViewControllerTest: XCTestCase {
     }
     
     func testTemperatureLabel() throws {
+        let expectation = self.expectation(description: "WeatherLoading")
         let weatherModel = MockWeatherModel { _, date in
-            Weather(name: "rainy", maxTemperature: 514, minTemperature: -114, date: date)
+            defer {
+                DispatchQueue.main.async {
+                    expectation.fulfill()
+                }
+            }
+            return Weather(name: "rainy", maxTemperature: 514, minTemperature: -114, date: date)
         }
         let viewController = WeatherViewController(weatherModel: weatherModel)
         viewController.reloadWeather()
+        wait(for: [expectation], timeout: 5)
         
         XCTAssertEqual(viewController.minTemperatureLabel.text, "-114")
         XCTAssertEqual(viewController.maxTemperatureLabel.text, "514")

--- a/WeatherTest/WeatherViewControllerTest.swift
+++ b/WeatherTest/WeatherViewControllerTest.swift
@@ -5,18 +5,24 @@
 //  Created by Zhou Chang on 2022/04/19.
 //
 
+import Combine
 import XCTest
 @testable import yumemi_ios_training
 
 struct MockWeatherModel: WeatherModel {
-    var onFetchWeather: (String, Date) throws -> Weather
     
-    func fetchWeather(area: String, date: Date) -> Result<Weather, Error> {
-        do {
-            return .success(try onFetchWeather(area, date))
-        } catch {
-            return .failure(error)
-        }
+    var onFetchWeather: (String, Date) throws -> Weather
+    var isLoading = CurrentValueSubject<Bool, Never>(false)
+    
+    func fetchWeather(area: String, date: Date) -> AnyPublisher<Weather, Error> {
+        isLoading.send(true)
+        return Future<Weather, Error> { promise in
+            do {
+                promise(.success(try onFetchWeather(area, date)))
+            } catch {
+                promise(.failure(error))
+            }
+        }.eraseToAnyPublisher()
     }
 }
 

--- a/WeatherTest/WeatherViewControllerTest.swift
+++ b/WeatherTest/WeatherViewControllerTest.swift
@@ -9,11 +9,14 @@ import XCTest
 @testable import yumemi_ios_training
 
 struct MockWeatherModel: WeatherModel {
-    
     var onFetchWeather: (String, Date) throws -> Weather
     
-    func fetchWeather(area: String, date: Date) throws -> Weather {
-        try onFetchWeather(area, date)
+    func fetchWeather(area: String, date: Date) -> Result<Weather, Error> {
+        do {
+            return .success(try onFetchWeather(area, date))
+        } catch {
+            return .failure(error)
+        }
     }
 }
 

--- a/WeatherTest/WeatherViewControllerTest.swift
+++ b/WeatherTest/WeatherViewControllerTest.swift
@@ -11,6 +11,7 @@ import XCTest
 
 struct MockWeatherModel: WeatherModel {
     
+    var isLoading = CurrentValueSubject<Bool, Never>(false)
     var onFetchWeather: (String, Date) throws -> Weather
     
     func requestWeather(area: String, date: Date, completion: @escaping (Result<Weather, Error>) -> Void) {

--- a/yumemi-ios-training/Model/WeatherModel.swift
+++ b/yumemi-ios-training/Model/WeatherModel.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+import Combine
 
 protocol WeatherModel {
-    func fetchWeather(area: String, date: Date) -> Result<Weather, Error>
+    var isLoading: CurrentValueSubject<Bool, Never> { get }
+    func fetchWeather(area: String, date: Date) -> AnyPublisher<Weather, Error>
 }

--- a/yumemi-ios-training/Model/WeatherModel.swift
+++ b/yumemi-ios-training/Model/WeatherModel.swift
@@ -1,14 +1,12 @@
 //
-//  WeatherModel+Impl.swift
+//  WeatherModel.swift
 //  yumemi-ios-training
 //
 //  Created by Zhou Chang on 2022/04/19.
 //
 
 import Foundation
-import Combine
 
 protocol WeatherModel {
-    var isLoading: CurrentValueSubject<Bool, Never> { get }
-    func fetchWeather(area: String, date: Date) -> AnyPublisher<Weather, Error>
+    func requestWeather(area: String, date: Date, completion: @escaping (Result<Weather, Error>) -> Void)
 }

--- a/yumemi-ios-training/Model/WeatherModel.swift
+++ b/yumemi-ios-training/Model/WeatherModel.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol WeatherModel {
-    func fetchWeather(area: String, date: Date) throws -> Weather
+    func fetchWeather(area: String, date: Date) -> Result<Weather, Error>
 }

--- a/yumemi-ios-training/Model/WeatherModel.swift
+++ b/yumemi-ios-training/Model/WeatherModel.swift
@@ -5,8 +5,10 @@
 //  Created by Zhou Chang on 2022/04/19.
 //
 
+import Combine
 import Foundation
 
 protocol WeatherModel {
+    var isLoading: CurrentValueSubject<Bool, Never> { get }
     func requestWeather(area: String, date: Date, completion: @escaping (Result<Weather, Error>) -> Void)
 }

--- a/yumemi-ios-training/Network/WeatherRequest+Client.swift
+++ b/yumemi-ios-training/Network/WeatherRequest+Client.swift
@@ -8,17 +8,22 @@ struct WeatherRequest: Codable, Equatable {
 
 final class WeatherClient: WeatherModel {
     
-    func fetchWeather(area: String, date: Date) throws -> Weather {
-        let request = WeatherRequest(area: area, date: date)
-        let requestData = try WeatherClient.encoder.encode(request)
-        guard let requestString = String(data: requestData, encoding: .utf8) else {
-            throw YumemiWeatherError.unknownError
+    func fetchWeather(area: String, date: Date) -> Result<Weather, Error> {
+        do {
+            let request = WeatherRequest(area: area, date: date)
+            let requestData = try WeatherClient.encoder.encode(request)
+            guard let requestString = String(data: requestData, encoding: .utf8) else {
+                return .failure(YumemiWeatherError.unknownError)
+            }
+            let reponseString = try YumemiWeather.syncFetchWeather(requestString)
+            guard let reponseData = reponseString.data(using: .utf8) else {
+                return .failure(YumemiWeatherError.unknownError)
+            }
+            let weather = try WeatherClient.decoder.decode(Weather.self, from: reponseData)
+            return .success(weather)
+        } catch {
+            return .failure(error)
         }
-        let reponseString = try YumemiWeather.syncFetchWeather(requestString)
-        guard let reponseData = reponseString.data(using: .utf8) else {
-            throw YumemiWeatherError.unknownError
-        }
-        return try WeatherClient.decoder.decode(Weather.self, from: reponseData)
     }
 }
 

--- a/yumemi-ios-training/Network/WeatherRequest+Client.swift
+++ b/yumemi-ios-training/Network/WeatherRequest+Client.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import YumemiWeather
 
@@ -7,23 +8,34 @@ struct WeatherRequest: Codable, Equatable {
 }
 
 final class WeatherClient: WeatherModel {
+    var isLoading = CurrentValueSubject<Bool, Never>(false)
     
-    func fetchWeather(area: String, date: Date) -> Result<Weather, Error> {
-        do {
-            let request = WeatherRequest(area: area, date: date)
-            let requestData = try WeatherClient.encoder.encode(request)
-            guard let requestString = String(data: requestData, encoding: .utf8) else {
-                return .failure(YumemiWeatherError.unknownError)
+    func fetchWeather(area: String, date: Date) -> AnyPublisher<Weather, Error> {
+        isLoading.send(true)
+        return Future<Weather, Error> { [isLoading] promise in
+            DispatchQueue.global().async {
+                defer {
+                    isLoading.send(false)
+                }
+                do {
+                    let request = WeatherRequest(area: area, date: date)
+                    let requestData = try WeatherClient.encoder.encode(request)
+                    guard let requestString = String(data: requestData, encoding: .utf8) else {
+                        promise(.failure(YumemiWeatherError.unknownError))
+                        return
+                    }
+                    let reponseString = try YumemiWeather.syncFetchWeather(requestString)
+                    guard let reponseData = reponseString.data(using: .utf8) else {
+                        promise(.failure(YumemiWeatherError.unknownError))
+                        return
+                    }
+                    let weather = try WeatherClient.decoder.decode(Weather.self, from: reponseData)
+                    promise(.success(weather))
+                } catch {
+                    promise(.failure(error))
+                }
             }
-            let reponseString = try YumemiWeather.syncFetchWeather(requestString)
-            guard let reponseData = reponseString.data(using: .utf8) else {
-                return .failure(YumemiWeatherError.unknownError)
-            }
-            let weather = try WeatherClient.decoder.decode(Weather.self, from: reponseData)
-            return .success(weather)
-        } catch {
-            return .failure(error)
-        }
+        }.eraseToAnyPublisher()
     }
 }
 

--- a/yumemi-ios-training/Network/WeatherRequest+Client.swift
+++ b/yumemi-ios-training/Network/WeatherRequest+Client.swift
@@ -14,7 +14,7 @@ final class WeatherClient: WeatherModel {
         guard let requestString = String(data: requestData, encoding: .utf8) else {
             throw YumemiWeatherError.unknownError
         }
-        let reponseString = try YumemiWeather.fetchWeather(requestString)
+        let reponseString = try YumemiWeather.syncFetchWeather(requestString)
         guard let reponseData = reponseString.data(using: .utf8) else {
             throw YumemiWeatherError.unknownError
         }

--- a/yumemi-ios-training/Network/WeatherRequest+Client.swift
+++ b/yumemi-ios-training/Network/WeatherRequest+Client.swift
@@ -8,8 +8,15 @@ struct WeatherRequest: Codable, Equatable {
 }
 
 final class WeatherClient: WeatherModel {
+    
+    var isLoading = CurrentValueSubject<Bool, Never>(false)
+    
     func requestWeather(area: String, date: Date, completion: @escaping (Result<Weather, Error>) -> Void) {
-        DispatchQueue.global().async {
+        isLoading.send(true)
+        DispatchQueue.global().async { [isLoading] in
+            defer {
+                isLoading.send(false)
+            }
             do {
                 let request = WeatherRequest(area: area, date: date)
                 let requestData = try WeatherClient.encoder.encode(request)

--- a/yumemi-ios-training/View/WeatherViewController.swift
+++ b/yumemi-ios-training/View/WeatherViewController.swift
@@ -137,17 +137,17 @@ class WeatherViewController: UIViewController {
     
     @objc func reloadWeather() {
         activityView.startAnimating()
-        DispatchQueue.global().async {
+        DispatchQueue.global().async { [weatherModel, weak self] in
             do {
-                let weather = try self.weatherModel.fetchWeather(area: "Tokyo", date: Date())
+                let weather = try weatherModel.fetchWeather(area: "Tokyo", date: Date())
                 DispatchQueue.main.async {
-                    self.showWeather(weather)
-                    self.activityView.stopAnimating()
+                    self?.showWeather(weather)
+                    self?.activityView.stopAnimating()
                 }
             } catch {
                 DispatchQueue.main.async {
-                    self.presentError(error, showErrorDetail: false)
-                    self.activityView.stopAnimating()
+                    self?.presentError(error, showErrorDetail: false)
+                    self?.activityView.stopAnimating()
                 }
             }
         }

--- a/yumemi-ios-training/View/WeatherViewController.swift
+++ b/yumemi-ios-training/View/WeatherViewController.swift
@@ -137,20 +137,28 @@ class WeatherViewController: UIViewController {
     }
     
     @objc func reloadWeather() {
-        activityView.startAnimating()
+        setLoadingState(isLoading: true)
         DispatchQueue.global().async { [weatherModel, weak self] in
-            do {
-                let weather = try weatherModel.fetchWeather(area: "Tokyo", date: Date())
-                DispatchQueue.main.async {
+            let weatherResult = weatherModel.fetchWeather(area: "Tokyo", date: Date())
+            DispatchQueue.main.async {
+                switch weatherResult {
+                case .success(let weather):
                     self?.showWeather(weather)
-                    self?.activityView.stopAnimating()
-                }
-            } catch {
-                DispatchQueue.main.async {
+                case .failure(let error):
                     self?.presentError(error, showErrorDetail: false)
-                    self?.activityView.stopAnimating()
                 }
+                self?.setLoadingState(isLoading: false)
             }
+        }
+    }
+    
+    private func setLoadingState(isLoading: Bool) {
+        if isLoading {
+            activityView.startAnimating()
+            reloadButton.isEnabled = false
+        } else {
+            activityView.stopAnimating()
+            reloadButton.isEnabled = true
         }
     }
     

--- a/yumemi-ios-training/View/WeatherViewController.swift
+++ b/yumemi-ios-training/View/WeatherViewController.swift
@@ -109,7 +109,7 @@ class WeatherViewController: UIViewController {
     }
     
     private func setViewsProperties() {
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
         
         minTemperatureLabel.text = "--"
         minTemperatureLabel.textColor = .systemBlue
@@ -121,6 +121,7 @@ class WeatherViewController: UIViewController {
         maxTemperatureLabel.font = .preferredFont(forTextStyle: .title1)
         
         dateLabel.text = "--"
+        dateLabel.textColor = .label
         dateLabel.textAlignment = .center
         
         closeButton.setTitle(NSLocalizedString("Close", comment: ""), for: .normal)

--- a/yumemi-ios-training/View/WeatherViewController.swift
+++ b/yumemi-ios-training/View/WeatherViewController.swift
@@ -29,6 +29,8 @@ class WeatherViewController: UIViewController {
         return formatter
     }()
     
+    let activityView = UIActivityIndicatorView()
+    
     var weatherModel: WeatherModel
     
     init(weatherModel: WeatherModel) {
@@ -97,6 +99,13 @@ class WeatherViewController: UIViewController {
             make.centerX.equalToSuperview()
             make.bottom.equalTo(infoContainerLayoutGuide.snp.top).offset(-40)
         }
+        
+        view.addSubview(activityView)
+        activityView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(infoContainerLayoutGuide.snp.bottom)
+            make.bottom.equalTo(closeButton.snp.top)
+        }
     }
     
     private func setViewsProperties() {
@@ -127,11 +136,20 @@ class WeatherViewController: UIViewController {
     }
     
     @objc func reloadWeather() {
-        do {
-            let weather = try weatherModel.fetchWeather(area: "Tokyo", date: Date())
-            showWeather(weather)
-        } catch {
-            presentError(error, showErrorDetail: false)
+        activityView.startAnimating()
+        DispatchQueue.global().async {
+            do {
+                let weather = try self.weatherModel.fetchWeather(area: "Tokyo", date: Date())
+                DispatchQueue.main.async {
+                    self.showWeather(weather)
+                    self.activityView.stopAnimating()
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self.presentError(error, showErrorDetail: false)
+                    self.activityView.stopAnimating()
+                }
+            }
         }
     }
     

--- a/yumemi-ios-training/View/WeatherViewController.swift
+++ b/yumemi-ios-training/View/WeatherViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Zhou Chang on 2022/04/07.
 //
 
+import Combine
 import UIKit
 import SnapKit
 
@@ -32,10 +33,17 @@ class WeatherViewController: UIViewController {
     let activityView = UIActivityIndicatorView()
     
     private var weatherModel: WeatherModel
+    private var loadingStateSubscription: AnyCancellable?
     
     init(weatherModel: WeatherModel) {
         self.weatherModel = weatherModel
         super.init(nibName: nil, bundle: nil)
+        
+        loadingStateSubscription = self.weatherModel.isLoading
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.setLoadingState(isLoading: $0)
+            }
     }
     
     required init?(coder: NSCoder) {
@@ -136,7 +144,6 @@ class WeatherViewController: UIViewController {
     }
     
     @objc func reloadWeather() {
-        setLoadingState(isLoading: true)
         weatherModel.requestWeather(area: "Tokyo", date: Date()) { [weak self] result in
             DispatchQueue.main.async {
                 switch result {
@@ -145,18 +152,7 @@ class WeatherViewController: UIViewController {
                 case .success(let weather):
                     self?.showWeather(weather)
                 }
-                self?.setLoadingState(isLoading: false)
             }
-        }
-    }
-    
-    private func setLoadingState(isLoading: Bool) {
-        if isLoading {
-            activityView.startAnimating()
-            reloadButton.isEnabled = false
-        } else {
-            activityView.stopAnimating()
-            reloadButton.isEnabled = true
         }
     }
     


### PR DESCRIPTION
## [Session 9 課題](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/ThreadBlock.md)
- 呼び出しAPIを`Sync ver`に変更する
- APIの処理が戻るまでUIActivityIndicatorを表示する

## [Session 11 課題](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Closure.md)
- コールバック形式で受け取るように変更する
- ViewControllerを閉じた時に`deinit`が呼ばれることを確認する

## 結果
<img src="https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Images/ThreadBlock.gif?raw=true" width="350">

## 実装
~~この課題の後にある３つの課題が [Delegate](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Delegate.md), [Closure](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Closure.md), [Concurrency](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Concurrency.md) のなで、この３つのパターンを使わず、Loading 状態の管理と Thread の制御が全部 VC 内に行うのがこの課題の目的だと認識していますが合ってますか？~~
Callback を使いました。